### PR TITLE
chore: bump aws creds and opentofu action versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,13 +32,13 @@ runs:
         which cdktf
         cdktf --version
     - name: Assume role using OIDC
-      uses: aws-actions/configure-aws-credentials@v5.1.1
+      uses: aws-actions/configure-aws-credentials@v6.0.0
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.aws_role }}
         role-session-name: ${{ inputs.aws_session_name }}
     - name: OpenTofu
-      uses: opentofu/setup-opentofu@v1.0.7
+      uses: opentofu/setup-opentofu@v1.0.8
       with:
         tofu_version: 1.10.6
     - name: Run build


### PR DESCRIPTION
## Summary
- bump `aws-actions/configure-aws-credentials` from `v5.1.1` to `v6.0.0`
- bump `opentofu/setup-opentofu` from `v1.0.7` to `v1.0.8`

## Validation
- `act --container-architecture linux/amd64 --container-daemon-socket - --container-options "--memory 4g" workflow_dispatch -W .github/workflows/build.yml -j build -s GITHUB_TOKEN="$TOKEN"`
- result: success
