### PR TITLE
fix(cdktf-build): pin cdktf-cli and correct the README title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,12 @@ name: Build
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
+  # The merge queue needs `build` and `Lint PR title` to report on the
+  # queue ref. merge_group alone was not dispatching, so mirror the
+  # push-on-queue-ref trigger the review workflows already use.
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group:
     types: [checks_requested]
   workflow_dispatch: {}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,10 @@ name: Build
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
-  # The merge queue needs `build` and `Lint PR title` to report on the
-  # queue ref. merge_group alone was not dispatching, so mirror the
-  # push-on-queue-ref trigger the review workflows already use.
+  # The merge queue needs `build` to report on the queue ref. merge_group
+  # alone was not dispatching, so mirror the push-on-queue-ref trigger the
+  # review workflows already use. `Lint PR title` is also emitted by
+  # pull-request-lint.yml, which already carries this trigger.
   push:
     branches:
       - gh-readonly-queue/**
@@ -18,7 +19,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: build-${{ github.event.pull_request.number || github.ref }}
+  group: build-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -38,8 +39,8 @@ jobs:
       pull-requests: read
     steps:
       - name: Skip PR title lint in merge queue context
-        if: github.event_name == 'merge_group'
-        run: echo "No PR title in merge_group event; marking check successful."
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "No PR title in merge_group/push event; marking check successful."
       - name: Lint PR title
         if: github.event_name == 'pull_request'
         uses: p6m7g8-actions/p6-gh-pr-title-linter@main

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Usage
 
 ```yaml
-      - name: CDK Build
+      - name: CDKTF Build
         uses: p6m7g8-actions/cdktf-build@main
         with:
           aws_region: ${{ secrets.CDK_DEPLOY_REGION }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# p6m7g8-actions/cdk-build
+# p6m7g8-actions/cdktf-build
 
-- [p6m7g8-actions/cdk-build](#p6m7g8-actionscdk-build)
+- [p6m7g8-actions/cdktf-build](#p6m7g8-actionscdktf-build)
   - [Usage](#usage)
 
 ## Usage

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: CDKTF bootstrap
       shell: bash
       run: |
-        npm install --global cdktf-cli@latest
+        npm install --global cdktf-cli@0.21.0
         which cdktf
         cdktf --version
     - name: Assume role using OIDC


### PR DESCRIPTION
**What:** Pin `cdktf-cli` to `0.21.0` instead of `@latest`, correct the README title and TOC anchor from `cdk-build` to `cdktf-build`, and add the `push: gh-readonly-queue/**` rider to `.github/workflows/build.yml`.

**Why:**

`npm install --global cdktf-cli@latest` resolved at job execution time, so the toolchain was non-deterministic. Two concrete consequences: an overnight upstream release could break every consumer of this action with no change on our side, and `cdktf-cli` could drift out of step with the OpenTofu version this same action pins to `1.10.6`. Pinning removes both.

`0.21.0` was chosen because it is the current stable release (npm `latest` dist-tag; `0.21.0-pre.170` is a prerelease on `next`) and it is the release contemporary with the OpenTofu `1.10` line — `cdktf-cli 0.21.0` shipped 2025-06-04 and OpenTofu `1.10.0` shipped 2025-06-24. The previous stable, `0.20.12` (2025-04-17), predates the `1.10` line entirely. The same version is pinned in `p6m7g8-actions/cdktf-deploy` so the two cannot drift.

The README was titled and self-linked as `p6m7g8-actions/cdk-build`. That is a copy-paste error from a genuinely different action in this org (`p6m7g8-actions/cdk-build` exists and its README correctly says `cdk-build`), so the wrong title was actively misleading rather than merely cosmetic.

The build.yml rider is required for this PR to merge at all. `merge_group` stopped dispatching org-wide — the last `merge_group` run anywhere in the org was 2026-03-09, with all workflows reporting `active`. As a result `build` and `Lint PR title` never report on `gh-readonly-queue` refs and the PR is dequeued after the 7-minute check timeout. `claude-review.yml` and `pull-request-lint.yml` already carry this trigger in every repo, which is why `build` was the only unreported check. This repo did not have the rider, so it was needed here.

**Test plan:**

- `actionlint .github/workflows/*.yml` — clean.
- `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"` — parses.
- Every `run:` block in `action.yml` extracted and run through `shellcheck -S warning -s bash` — clean (both blocks, rc=0).
- `yamllint` with the relaxed 120-column config that `p6m7g8-actions/yamllint` generates — warnings only, no errors.
- `markdownlint-cli '**/*.md'` with the 120-column config that `p6m7g8-actions/p6-gh-markdown-linter` generates — clean.
- `npm view cdktf-cli@0.21.0 version` — confirms the pinned version resolves and is published.
- `act` was not usable: it fails pre-push at `actions/checkout` with `upload-pack: not our ref`. Relying on the remote GHA run.

**Dependencies:** Depends on Wave 1 (all merged).