### PR TITLE
refactor: adopt renamed action names in workflows

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Auto-Approve PR
-        uses: p6m7g8-actions/p6-gh-pr-auto-approve@main
+        uses: p6m7g8-actions/p6-gh-pr-approve@main
         with:
           bot_token: ${{ secrets.P6_A_GH_TOKEN }}

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -18,6 +18,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Enqueue PR
-        uses: p6m7g8-actions/p6-gh-pr-auto-enqueue@main
+        uses: p6m7g8-actions/p6-gh-pr-enqueue@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build
-        uses: p6m7g8-actions/p6-build@main
+        uses: p6m7g8-actions/p6-repo-build@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -52,6 +52,6 @@ jobs:
         run: echo "No PR title in merge_group event; marking check successful."
       - name: Lint PR title
         if: github.event_name == 'pull_request'
-        uses: p6m7g8-actions/p6-gh-pr-title-linter@main
+        uses: p6m7g8-actions/p6-gh-pr-title-lint@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Run claude review
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
         continue-on-error: true
-        uses: p6m7g8-actions/claude@main
+        uses: p6m7g8-actions/p6-code-review@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,6 +16,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR
-        uses: p6m7g8-actions/p6-gh-pr-labeler@main
+        uses: p6m7g8-actions/p6-gh-pr-label@main
         with:
           gh_token: ${{ secrets.P6_A_GH_TOKEN }}

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -26,6 +26,6 @@ jobs:
         run: echo "Skipping lint in queue context"
       - name: Lint PR title
         if: github.event_name == 'pull_request_target'
-        uses: p6m7g8-actions/p6-gh-pr-title-linter@main
+        uses: p6m7g8-actions/p6-gh-pr-title-lint@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
       contents: write
     steps:
       - name: Release
-        uses: p6m7g8-actions/p6-gh-release@main
+        uses: p6m7g8-actions/p6-gh-release-cut@main
         with:
           gh_token: ${{ secrets.P6_A_GH_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: p6m7g8-actions/checkout@main
+        uses: p6m7g8-actions/gh-repo-checkout@main
       - name: Smoke
         shell: bash
         run: echo "smoke ok"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,4 +14,4 @@ jobs:
       pull-requests: write
     steps:
       - name: Mark PR
-        uses: p6m7g8-actions/p6-gh-pr-stale@main
+        uses: p6m7g8-actions/p6-gh-pr-expire@main


### PR DESCRIPTION
**What:** Rewrites `uses:` refs in `.github/workflows/` to the renamed action names.

**Why:** The rename wave's cross-reference sweep missed every workflow file. It used `fd -e yml -e yaml -e md`, and **`fd` skips hidden directories by default**, so `.github/workflows/` was never visited — only root-level `action.yml` and `README.md` were rewritten.

Worse, the verification I ran afterwards checked `action.yml` only, so it reported "0 stale refs" and passed. It could not have caught this.

Nothing was broken by the gap: GitHub's rename redirects keep old refs working, which is also why it went unnoticed. But it has a concrete consequence. `p6-gh-workflow-distribute` now skips `build.yml` when a target's build action differs from its org template, and measured across the org, **35 of 35** targets still said `p6-build` against a template naming `p6-repo-build`. Those are the *same archetype under its old name*, so distribution would have skipped `build.yml` for every target while the notices read as intended behavior.

**Test plan:** Substitutions are anchored on the trailing `@`, so `cdk-build@` cannot match inside `cdk-construct-build@`, and no new name is also an old name, which makes the rewrite idempotent. `p6df-build` is deliberately unchanged. This PR's own `build` run exercises the rewritten refs.

**Dependencies:** none. Every PR in this batch is independent. Should land before the next distribution run to `p6m7g8-actions`.
